### PR TITLE
allow the aws default credential provider chain to be used if no credentials were explicitly supplied in the build

### DIFF
--- a/subprojects/resources-s3/src/main/java/org/gradle/internal/resource/transport/aws/s3/S3Client.java
+++ b/subprojects/resources-s3/src/main/java/org/gradle/internal/resource/transport/aws/s3/S3Client.java
@@ -21,10 +21,12 @@ import com.amazonaws.AmazonServiceException;
 import com.amazonaws.ClientConfiguration;
 import com.amazonaws.auth.AWSCredentials;
 import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
 import com.amazonaws.services.s3.AmazonS3Client;
 import com.amazonaws.services.s3.S3ClientOptions;
 import com.amazonaws.services.s3.model.*;
 import com.google.common.base.Optional;
+import com.google.common.base.Strings;
 import org.gradle.api.artifacts.repositories.PasswordCredentials;
 import org.gradle.api.credentials.AwsCredentials;
 import org.gradle.internal.resource.ResourceException;
@@ -53,8 +55,23 @@ public class S3Client {
 
     public S3Client(AwsCredentials awsCredentials, S3ConnectionProperties s3ConnectionProperties) {
         this.s3ConnectionProperties = s3ConnectionProperties;
-        AWSCredentials credentials = awsCredentials == null ? null : new BasicAWSCredentials(awsCredentials.getAccessKey(), awsCredentials.getSecretKey());
+        AWSCredentials credentials = createCredentials(awsCredentials);
         amazonS3Client = createAmazonS3Client(credentials);
+    }
+
+    private AWSCredentials createCredentials(AwsCredentials credentials) {
+        if (credentials == null) {
+            return null;
+        }
+
+        // if credentials were provided through the build script, use those exclusively
+        if (!Strings.isNullOrEmpty(credentials.getAccessKey()) || !Strings.isNullOrEmpty(credentials.getSecretKey())) {
+            // create a credential provider around the given AwsCredentials
+            return new BasicAWSCredentials(credentials.getAccessKey(), credentials.getSecretKey());
+        } else {
+            // otherwise, use the AWS default credential chain
+            return new DefaultAWSCredentialsProviderChain().getCredentials();
+        }
     }
 
     private AmazonS3Client createAmazonS3Client(AWSCredentials credentials) {


### PR DESCRIPTION
@mdodsworth 
There's another bug we need to patch for gradle + s3 integration. I've created an "optimizely" branch to be our dev master. The "master" branch will be a mirror of upstream master. In this PR I'm merging your change into optimizely branch.
