### PR TITLE
Bump up joda-time version to resolve issue with JDK 8u60

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -160,7 +160,7 @@ libraries.bouncycastle_pgp = dependencies.module("org.bouncycastle:bcpg-jdk15on:
     dependency libraries.bouncycastle_provider
 }
 
-libraries.joda = 'joda-time:joda-time:2.7@jar'
+libraries.joda = 'joda-time:joda-time:2.8.2@jar'
 
 libraries.awsS3 = [
         'com.amazonaws:aws-java-sdk-s3:1.9.19@jar',


### PR DESCRIPTION
https://discuss.gradle.org/t/fetching-artifacts-from-s3-backed-repository-fails-with-jdk8u60/11298
